### PR TITLE
fix: `StorageType` type to enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcana/scw",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "main": "dist/standalone.mjs",
   "type": "module",
   "module": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,9 @@ export type SupportedNetwork = {
   currency: string,
 }
 
-export type { Transaction, StorageType, Rule }
+export type { Transaction,  Rule }
+
+export { StorageType }
 
 export type SmartWalletTransaction = {
   to: Hex,


### PR DESCRIPTION
# Changes
Export `StorageType` as enum instead of type

- [x] Version upgrade -> 0.0.41 